### PR TITLE
Update replicate_flux_pipeline.py

### DIFF
--- a/examples/pipelines/integrations/replicate_flux_pipeline.py
+++ b/examples/pipelines/integrations/replicate_flux_pipeline.py
@@ -42,10 +42,8 @@ class Pipeline:
             )
 
             # 画像URLを取得
-            image_url = output[0]
             print(output)
-            message = "![image](" + output + ")\n"
-            # return f"URL to the image: {output}"
+            message = f"![image]({output})\n"
             return message
             
 


### PR DESCRIPTION
The api has changed. Now it directly returns the url as the output but not inside a list.

see the updated example:
https://replicate.com/black-forest-labs/flux-1.1-pro/api